### PR TITLE
better site check error output

### DIFF
--- a/scripts/check_site.lua
+++ b/scripts/check_site.lua
@@ -1,7 +1,7 @@
 local cjson = require 'cjson'
 
 local function config_error(src, ...)
-	error(src .. ' error: ' .. string.format(...), 0)
+	error(src .. ' config_error: ' .. string.format(...), 0)
 end
 
 local has_domains = (os.execute('ls -d "$IPKG_INSTROOT"/lib/gluon/domains/ >/dev/null 2>&1') == 0)


### PR DESCRIPTION
This small change will make those errors more easily distinguishable from other less important errors in the build-log.